### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: default deps lint test wheel run
+
+DEFAULT_TARGETS := deps lint test wheel
+
+# default target: install deps, run linter & tests, build wheel
+default: $(DEFAULT_TARGETS)
+
+# install python dependencies
+deps:
+	pip install -r requirements.txt
+
+lint:
+	flake8 src tests
+
+test:
+	pytest
+
+wheel:
+	python setup.py bdist_wheel
+
+# optional run target to launch the game
+run:
+	python -m fluxagama.fluxagama

--- a/README.md
+++ b/README.md
@@ -4,3 +4,8 @@ fluxagama
 2d vertical shooter based on PyGame.
 
 http://nczempin.github.com/fluxagama/
+
+Development
+-----------
+Run `make` to install dependencies, execute linters and tests, and build a
+wheel in `dist/`.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='fluxagama',
+    version='0.0.0',
+    package_dir={'': 'src'},
+    packages=find_packages('src'),
+)


### PR DESCRIPTION
## Summary
- add setup.py
- add Makefile with default automation for installation, linting, testing and wheel build
- document `make` usage in README

## Testing
- `flake8 src tests` *(fails: various style errors)*
- `pytest -q`
- `python setup.py bdist_wheel` *(fails: 'bdist_wheel' command not found)*