### PR TITLE
Fix Python module import issues to make fluxagama runnable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+pygame
 flake8
 pytest

--- a/src/fluxagama/Enemy.py
+++ b/src/fluxagama/Enemy.py
@@ -1,6 +1,6 @@
 import pygame
-import graphics
-import FluxaSprite
+from . import graphics
+from . import FluxaSprite
 enemy_filenames = ("enemy00.png","enemy01.png", "enemy02.png")
 class Enemy(FluxaSprite.FluxaSprite):
     '''

--- a/src/fluxagama/FluxaSprite.py
+++ b/src/fluxagama/FluxaSprite.py
@@ -1,6 +1,6 @@
 import pygame
-import graphics
-from constants import *
+from . import graphics
+from .constants import *
 class FluxaSprite(pygame.sprite.Sprite):
     def __init__(self, position,image):
         pygame.sprite.Sprite.__init__(self)

--- a/src/fluxagama/PlayerShip.py
+++ b/src/fluxagama/PlayerShip.py
@@ -1,5 +1,7 @@
-import pygame, graphics, FluxaSprite
-from constants import *
+import pygame
+from . import graphics
+from . import FluxaSprite
+from .constants import *
 class PlayerShip(FluxaSprite.FluxaSprite):
     def __init__(self,position):
         FluxaSprite.FluxaSprite.__init__(self,position,'gun.png')

--- a/src/fluxagama/Shot.py
+++ b/src/fluxagama/Shot.py
@@ -1,4 +1,6 @@
-import pygame, graphics,FluxaSprite
+import pygame
+from . import graphics
+from . import FluxaSprite
 class Shot(FluxaSprite.FluxaSprite):
     def __init__(self, position):
         FluxaSprite.FluxaSprite.__init__(self,position,'shot.png')

--- a/src/fluxagama/__init__.py
+++ b/src/fluxagama/__init__.py
@@ -1,0 +1,1 @@
+# Fluxagama game package

--- a/src/fluxagama/explosion.py
+++ b/src/fluxagama/explosion.py
@@ -1,6 +1,6 @@
 import pygame
-import graphics
-import FluxaSprite
+from . import graphics
+from . import FluxaSprite
 #explosion_image = graphics.load_image("explosion00.png")
 
 e = None

--- a/src/fluxagama/fluxagama.py
+++ b/src/fluxagama/fluxagama.py
@@ -2,14 +2,14 @@ from __future__ import print_function
 import pygame
 import random
 from pygame.locals import *
-from constants import *
-import graphics
-import sound
-import text
-import Enemy
-import PlayerShip
-import Shot
-import explosion
+from .constants import *
+from . import graphics
+from . import sound
+from . import text
+from . import Enemy
+from . import PlayerShip
+from . import Shot
+from . import explosion
 
 def collidesWith(sprite1, sprite2):
     x1 = sprite1.position[0]
@@ -38,7 +38,7 @@ def generate_enemy_wave(enemies):
     for i in range(ENEMY_ROWS):
         for j in range(ENEMY_COLUMNS):
             position = [60 + j * 50, BORDER_UPPER + 110 + i * 50]
-            enemyType = 2-(i+1)/2
+            enemyType = 2-(i+1)//2
             enemy_sprite = Enemy.Enemy(enemyType, position)
             enemies.append(enemy_sprite)
  
@@ -188,5 +188,7 @@ def main():
     init() 
     game_loop()
     pygame.quit()    
-main()
+
+if __name__ == "__main__":
+    main()
 

--- a/src/fluxagama/graphics.py
+++ b/src/fluxagama/graphics.py
@@ -1,11 +1,15 @@
 from __future__ import print_function
 import os
 import pygame
-from constants import *
+from .constants import *
 def load_image(filename):
     "loads an image, prepares it for play"
     print("Loading image " + filename)
-    filename = os.path.join("../../data", filename)
+    # Get the directory where this module is located
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    # Go up two levels to get to the project root, then into data
+    data_dir = os.path.join(current_dir, "..", "..", "data")
+    filename = os.path.join(data_dir, filename)
     try:
         surface = pygame.image.load(filename)
     except pygame.error:

--- a/src/fluxagama/sound.py
+++ b/src/fluxagama/sound.py
@@ -8,7 +8,11 @@ class dummysound:
 def load_sound(filename):
     if not pygame.mixer: return dummysound()
     print("Loading sound " + filename)
-    filename = os.path.join("../../data", filename)
+    # Get the directory where this module is located
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    # Go up two levels to get to the project root, then into data
+    data_dir = os.path.join(current_dir, "..", "..", "data")
+    filename = os.path.join(data_dir, filename)
     try:
         sound = pygame.mixer.Sound(filename)
         return sound

--- a/src/fluxagama/text.py
+++ b/src/fluxagama/text.py
@@ -1,5 +1,5 @@
 import pygame
-from constants import *
+from .constants import *
 
 score1titletext=None
 score1titletextpos=None

--- a/test_game.py
+++ b/test_game.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+Simple test script to verify that the fluxagama game can be imported and started.
+This script will start the game for a few seconds and then exit.
+"""
+
+import os
+import sys
+import signal
+import time
+import subprocess
+
+def test_game_import():
+    """Test that the game can be imported without errors."""
+    try:
+        import fluxagama.fluxagama
+        print("✓ Game module imported successfully")
+        return True
+    except ImportError as e:
+        print(f"✗ Failed to import game module: {e}")
+        return False
+
+def test_game_startup():
+    """Test that the game can start without immediate crashes."""
+    try:
+        # Start the game process
+        process = subprocess.Popen(
+            [sys.executable, "-m", "fluxagama.fluxagama"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+        
+        # Let it run for 2 seconds
+        time.sleep(2)
+        
+        # Terminate the process
+        process.terminate()
+        
+        # Wait for it to finish and get output
+        stdout, stderr = process.communicate(timeout=5)
+        
+        # Check if it started successfully (should load images)
+        if "Loading image" in stdout or "Loading image" in stderr:
+            print("✓ Game started successfully and loaded assets")
+            return True
+        else:
+            print(f"✗ Game may not have started properly")
+            print(f"stdout: {stdout}")
+            print(f"stderr: {stderr}")
+            return False
+            
+    except Exception as e:
+        print(f"✗ Failed to start game: {e}")
+        return False
+
+if __name__ == "__main__":
+    print("Testing Fluxagama game...")
+    print()
+    
+    # Test import
+    import_success = test_game_import()
+    
+    # Test startup
+    startup_success = test_game_startup()
+    
+    print()
+    if import_success and startup_success:
+        print("🎉 All tests passed! The game is working correctly.")
+        sys.exit(0)
+    else:
+        print("❌ Some tests failed.")
+        sys.exit(1)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -8,26 +8,36 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 pygame = types.ModuleType('pygame')
 pygame.sprite = types.ModuleType('sprite')
 pygame.sprite.Sprite = object
+pygame.error = Exception
+pygame.image = types.ModuleType('image')
+def dummy_load(filename):
+    class DummySurface:
+        def get_size(self):
+            return (0, 0)
+    return DummySurface()
+pygame.image.load = dummy_load
 sys.modules['pygame'] = pygame
 
-graphics = types.ModuleType('graphics')
+# Mock the fluxagama.graphics module
+fluxagama_graphics = types.ModuleType('fluxagama.graphics')
 class DummySurface:
     def get_size(self):
         return (0, 0)
 
 def load_image(_):
     return DummySurface()
-graphics.load_image = load_image
-sys.modules['graphics'] = graphics
+fluxagama_graphics.load_image = load_image
+sys.modules['fluxagama.graphics'] = fluxagama_graphics
 
-FluxaSprite = types.ModuleType('FluxaSprite')
+# Mock the fluxagama.FluxaSprite module
+fluxagama_FluxaSprite = types.ModuleType('fluxagama.FluxaSprite')
 class FluxaSpriteBase(pygame.sprite.Sprite):
     def __init__(self, position, image):
         self.position = position
-        self.image = graphics.load_image(image)
+        self.image = fluxagama_graphics.load_image(image)
         self.size = self.image.get_size()
-FluxaSprite.FluxaSprite = FluxaSpriteBase
-sys.modules['FluxaSprite'] = FluxaSprite
+fluxagama_FluxaSprite.FluxaSprite = FluxaSpriteBase
+sys.modules['fluxagama.FluxaSprite'] = fluxagama_FluxaSprite
 
 from fluxagama import Enemy
 


### PR DESCRIPTION
## Summary
Fixes issue #59 by resolving Python module import issues that prevented the game from running with `python -m fluxagama.fluxagama`.

## Changes Made

### Package Structure
- ✅ Added missing `__init__.py` file to `src/fluxagama/` to make it a proper Python package

### Import Fixes
- ✅ Converted all absolute imports to relative imports in all Python modules:
  - `from constants import *` → `from .constants import *`
  - `import graphics` → `from . import graphics`
  - Applied to: `fluxagama.py`, `graphics.py`, `FluxaSprite.py`, `PlayerShip.py`, `text.py`, `Enemy.py`, `Shot.py`, `explosion.py`

### Asset Loading
- ✅ Fixed asset loading paths in `graphics.py` and `sound.py` to use proper path resolution
- ✅ Changed from hardcoded relative paths to dynamic path calculation using `__file__` location

### Dependencies
- ✅ Added `pygame` to `requirements.txt` (was missing despite being used)

### Bug Fixes
- ✅ Fixed integer division issue in enemy type calculation (`/` → `//`)
- ✅ Added proper `if __name__ == '__main__'`:` guard to prevent auto-execution on import

### Testing
- ✅ Updated test mocks to work with new relative import structure
- ✅ All tests pass
- ✅ Game starts successfully and loads all assets

## Verification
The game now works correctly:
```bash
$ python -m fluxagama.fluxagama
# Game starts successfully, loads all images, and runs without errors
```

## Testing
- ✅ Unit tests pass: `python -m pytest tests/ -v`
- ✅ Game import works without auto-execution
- ✅ Game startup verified with asset loading
- ✅ No regression in existing functionality

## Related Issues
- Addresses part of broader issue #44 "Get it working again"
- Game now starts but may need additional fixes for full gameplay functionality

Closes #59